### PR TITLE
removed useless FT index from schema

### DIFF
--- a/github-archive/schema.sql
+++ b/github-archive/schema.sql
@@ -1,18 +1,25 @@
 CREATE TABLE github (
     type STRING,
-    payload OBJECT AS(
-      commits OBJECT AS (
-        message STRING
-      )
+    payload OBJECT AS (
+      commits ARRAY(OBJECT AS (
+        sha STRING,
+        author OBJECT,
+        message STRING,
+        "distinct" BOOLEAN,
+        url STRING
+      ))
     ),
-    repo OBJECT,
+    repo OBJECT AS (
+      id LONG
+    ),
     actor OBJECT,
     org OBJECT,
     created_at TIMESTAMP,
     month_partition STRING,
     id STRING,
-    public BOOLEAN,
-    INDEX commit_comment_ft using fulltext(payload['commits']['message']) with (analyzer = 'english')
-    ) PARTITIONED BY (month_partition)
-    WITH (number_of_replicas=0,
-            refresh_interval=0);
+    public BOOLEAN
+) PARTITIONED BY (month_partition)
+WITH (
+    number_of_replicas = 0,
+    refresh_interval = 0
+);


### PR DESCRIPTION
and made payloads['commits'] an object array

we cannot use FT analyzer in object_array, but we would have to use LIKE predicate, e.g.

```
cr> select payload['commits']['message'] as messages from github where '%fuck%' LIKE ANY(payload['commits']['message']) limit 1;
+-----------------------------------+
| messages                          |
+-----------------------------------+
| ["fucking with linebreaks again"] |
+-----------------------------------+
SELECT 1 row in set (0.016 sec)
```
